### PR TITLE
Dynamically adjust pointer size to support 64bit

### DIFF
--- a/distance.asl
+++ b/distance.asl
@@ -106,11 +106,14 @@ init
 			var count = game.ReadValue<int>(dictPtr + (int)(dict["count"]));
 			IntPtr keys = game.ReadPointer(dictPtr + (int)(dict["keySlots"])), values = game.ReadPointer(dictPtr + (int)(dict["valueSlots"]));
 
+			int ptrSize = IntPtr.Size;
+			int arrayStart = ptrSize == 8 ? 0x20 : 0x10;
+
 			for (int i = 0; i < count; ++i)
 			{
-				var item = game.ReadString(game.ReadPointer(keys + 0x10 + 0x4 * i) + (int)(str["start_char"]), 64);
+				var item = game.ReadString(game.ReadPointer(keys + arrayStart + ptrSize * i) + (int)(str["start_char"]), 64);
 				if (item == key)
-					return game.ReadString(game.ReadPointer(values + 0x10 + 0x4 * i) + (int)(str["start_char"]), 64);
+					return game.ReadString(game.ReadPointer(values + arrayStart + ptrSize * i) + (int)(str["start_char"]), 64);
 			}
 
 			return null;


### PR DESCRIPTION
Ever since v1.5 updated the game to 64bit, the `vars.GetValue("Game Mode")` was failing to find the mode name, thus hitting the default case in the switch statement, and ignoring all split settings, so all cutscene maps were being split at.

The default case in the mode switch statement also caused LtE (and Nexus) to split on finish rather than on load start for the final map; this also fixes that.

(Also, hope you're doing well since we haven't spoken in a while 👍)